### PR TITLE
Allow thor up to 0.16.

### DIFF
--- a/chosen-rails.gemspec
+++ b/chosen-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Chosen::Rails::VERSION
 
   gem.add_dependency "railties", "~> 3.0"
-  gem.add_dependency "thor",     "~> 0.14"
+  gem.add_dependency "thor",     [">= 0.14", "<= 0.16"]
   gem.add_development_dependency "bundler", "~> 1.0"
   gem.add_development_dependency "rails",   "~> 3.0"
   gem.add_development_dependency "sass",    "~> 3.1"


### PR DESCRIPTION
Thor 0.16 works correctly so it would be nice to have a more lose dependency on it.

This is the output of comparing two branches that run the update task with the different versions of thor:

```
nikosd@vincent:chosen-rails(master)$ git diff updated_chosen_with_original_thor..updated_chosen_with_thor_0.16
diff --git a/chosen-rails.gemspec b/chosen-rails.gemspec
index 74f7394..d8ae68a 100644
--- a/chosen-rails.gemspec
+++ b/chosen-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Chosen::Rails::VERSION

   gem.add_dependency "railties", "~> 3.0"
-  gem.add_dependency "thor",     "~> 0.14"
+  gem.add_dependency "thor",     [">= 0.14", "<= 0.16"]
   gem.add_development_dependency "bundler", "~> 1.0"
   gem.add_development_dependency "rails",   "~> 3.0"
   gem.add_development_dependency "sass",    "~> 3.1"
```
