### PR TITLE
Better name for repository (?)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,8 @@ require 'bundler/gem_tasks'
 require File.expand_path('../lib/chosen-rails/source_file', __FILE__)
 
 desc "Update with Harvest's Chosen Library"
-task 'update-chosen', 'remote', 'branch' do |task, args|
-  remote = args['remote'] || 'https://github.com/harvesthq/chosen'
+task 'update-chosen', 'repository_url', 'branch' do |task, args|
+  remote = args['repository_url'] || 'https://github.com/harvesthq/chosen'
   branch = args['branch'] || 'master'
   files = SourceFile.new
   files.fetch remote, branch


### PR DESCRIPTION
I recently updated chosen-rails with the koenpunt fork. I love the `update-chosen` task, very convenient. I had two missteps due to the `remote` argument.
1. I thought it meant a git remote, so I used `git remote add`, no go.
2. After looking at the Rakefile, I realized it wanted a repository. I used the GitHub Clone URL button (home page of each repo). That didn't work either.

After looking at the Rakefile again, I realized that it wanted the URL without the .git at the end. Then things worked. Great.

I don't feel strongly about this change – or the specific argument name `repository_url`. Use it if you think it would help.
