### PR TITLE
updating compass-rails dependency to v1.1.2 w/ rails4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ Include `chosen-rails` in Gemefile
 
     gem 'chosen-rails'
 
-For Rails 4 project, it is required to add [compass-rails](https://github.com/Compass/compass-rails) gem explicitly.
-
-    gem 'compass-rails', github: 'Compass/compass-rails'
-
-Or use the prerelease gem
-
-    gem 'compass-rails', '~> 2.0.alpha.0'
-
 Then run `bundle install`
 
 ### Include chosen javascript assets

--- a/chosen-rails.gemspec
+++ b/chosen-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'railties', '>= 3.0'
   gem.add_dependency 'coffee-rails', '>= 3.2'
   gem.add_dependency 'sass-rails', '>= 3.2'
-  gem.add_dependency 'compass-rails', '>= 1.0'
+  gem.add_dependency 'compass-rails', '>= 1.1.2'
 
   gem.add_development_dependency 'bundler', '>= 1.0'
   gem.add_development_dependency 'rails', '>= 3.0'


### PR DESCRIPTION
compass-rails v2.0.alpha.0 has been yanked from rubygems.org in favor of
v1.1.2 which has been released w/ rails 4 support.

updating version dependency in gemspec and corresponding documentation

see:
- https://github.com/Compass/compass-rails/pull/113
- https://github.com/Compass/compass-rails/issues/116
