### PR TITLE
Added jquery-turbolinks to required gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The `chosen-rails` gem integrates the `Chosen` with the Rails asset pipeline.
 Include `chosen-rails` in Gemefile
 
     gem 'chosen-rails'
+    
+If you are using Rails 4, include `jquery-turbolinks` also in your Gemfile
+
+    gem 'jquery-turbolinks'
 
 Then run `bundle install`
 


### PR DESCRIPTION
Chosen-Rails is a great gem. But I was running into an issue when I tried to use it with Rails 4. If you don't reload the page, Chosen would go back to being a normal select tag. So I had to add jquery-turbolinks gem to get it back to run in its normal behavior.