### PR TITLE
Fix label lookups when id uses dashes

### DIFF
--- a/lib/chosen-rails/rspec.rb
+++ b/lib/chosen-rails/rspec.rb
@@ -34,7 +34,7 @@ module Chosen
       def chosen_find_container(from, options)
         from = from.to_s
 
-        id = from
+        id = from.underscore
         id = "##{id}" unless from.start_with?('#')
         id = "#{id}_chosen" unless from.end_with?('_chosen')
 
@@ -42,14 +42,14 @@ module Chosen
       rescue Capybara::ElementNotFound
         label = find('label', { text: from }.merge(options))
 
-        find(:css, "##{label[:for]}_chosen", options)
+        find(:css, "##{label[:for].underscore}_chosen", options)
       end
 
       def chosen_find_input(from, options)
         from = from.to_s
         from = "##{from}" unless from.start_with?('#')
 
-        find(:css, from, options)
+        find(:css, from.underscore, options)
       end
 
       def chosen_multiselect?(input)


### PR DESCRIPTION
When a select field's `id` includes dashes, Chosen converts them
to underscores on the Chosen element ids, which breaks lookup
expectations unexpectedly, especially if you're building a Rails
form with a namespace using a `dom_id` when the parent namespace
uses `uuid` for its primary key.

```ruby
thread = Thread.find(params[:id])
message = thread.messages.build

form_for [thread, message], namespace: dom_id(thread) do
  f.label :greeting, "Greeting"
  f.select :greeting, options_for_select("Hello", "Hi", "Hey")
end

chosen_select "Hello", from: "Greeting"
chosen_select "Hello", from: "thread_bad56da7-cf6c-434e-a054-a0a6dc0eb39d_message_greeting"
chosen_select "Hello", from: "#thread_bad56da7-cf6c-434e-a054-a0a6dc0eb39d_message_greeting"
chosen_select "Hello", from: "##{dom_id(thread)}_message_greeting"
```

This ensures that when looking up a chosen element, we convert to
underscores to match how Chosen maps a `select` `id` to a chosen
element `id`.