### PR TITLE
Fix forwarding keyword arguments to avoid deprecation in Ruby 2.7, error in Ruby 3.0

### DIFF
--- a/lib/chosen-rails/rspec.rb
+++ b/lib/chosen-rails/rspec.rb
@@ -38,18 +38,18 @@ module Chosen
         id = "##{id}" unless from.start_with?('#')
         id = "#{id}_chosen" unless from.end_with?('_chosen')
 
-        find(:css, id, options)
+        find(:css, id, **options)
       rescue Capybara::ElementNotFound
-        label = find('label', { text: from }.merge(options))
+        label = find('label', **{ text: from }.merge(options))
 
-        find(:css, "##{label[:for].underscore}_chosen", options)
+        find(:css, "##{label[:for].underscore}_chosen", **options)
       end
 
       def chosen_find_input(from, options)
         from = from.to_s
         from = "##{from}" unless from.start_with?('#')
 
-        find(:css, from.underscore, options)
+        find(:css, from.underscore, **options)
       end
 
       def chosen_multiselect?(input)


### PR DESCRIPTION
This is the deprecation shown otherwise:
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call